### PR TITLE
setup to allow custom styling

### DIFF
--- a/docs/_static/custom-pst.css
+++ b/docs/_static/custom-pst.css
@@ -1,0 +1,23 @@
+html {
+  /*****************************************************************************
+  * Overall Layout Variables
+  */
+
+  --pst-color-link: green;
+  --pst-color-inline-code: green!important;
+}
+
+html[data-theme="light"] {
+  --pst-color-link: black;
+  // Announcement
+  --sbt-color-announcement: rgb(97, 97, 97);
+  // Default primary color (need to adjust on dark theme due to bad contrast)
+  --pst-color-primary: #176de8;
+}
+html[data-theme="dark"] {
+  --pst-color-link: lightgreen;
+  // Announcement
+  --sbt-color-announcement: rgb(97, 97, 97);
+  // Default primary color (need to adjust on dark theme due to bad contrast)
+  --pst-color-primary: #176de8;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,8 @@ project = 'GeoRacoon'
 copyright = '2025, Simon Landauer, Jonas I. Liechti'
 author = 'Simon Landauer, Jonas I. Liechti'
 
+
+
 master_doc = 'index'
 
 release = ".".join(get_version('GeoRacoon').split('.')[:2])
@@ -44,21 +46,33 @@ favicons = [
 ]
 html_logo = "./GeoRacoon.png"
 
-html_theme = 'sphinx_rtd_theme'
+# html_theme = 'sphinx_rtd_theme'
 # html_theme = 'alabaster'
+html_theme = 'pydata_sphinx_theme'
+# html_theme = 'sphinx_book_theme'
 html_static_path = ['_static']
+html_css_files = ['custom-pst.css']
+
+html_context = {
+    "github_user": "GeoRacoon",
+    "github_repo": "GeoRacoon",
+    "github_version": "main",
+    "default_mode": "light",
+}
+
+# html_logo = '_static/<logo>.png'
+
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-html_theme = 'pydata_sphinx_theme'
-# html_theme = 'sphinx_book_theme'
-# html_css_files = ["custom.css"]
-# html_logo = '_static/<logo>.png'
 html_title = 'GeoRacoon'
 html_theme_options = {
+    "path_to_docs": "docs/",
+    "use_edit_page_button": True,
+    "use_repository_button": True,
     "navbar_start": ["navbar-logo"],
     "navbar_center": ["navbar-nav"],
-    "navbar_end": ["navbar-icon-links"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
     "navbar_persistent": ["search-button"],
     "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
     "footer_start": ["copyright", "sphinx-version"],


### PR DESCRIPTION
@simonsaysenjoy feel free to play around with this. in the custom-pst.css we can overwrite the `--pst-...` stylings as we please.
For some reason sometimes the `!important` is needed (don't ask me why :sweat_smile: ).

To change a color of an item, I'd just open the html page inspector, select the item you want to stle with the inspector and find the active `--pst-...` in the sytles.

We can also just leave this as is for now and close the pull request, up to you!

The important part to include the custom styling is this:
https://github.com/GeoRacoon/GeoRacoon/pull/131/changes#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3R54