### PR TITLE
publish on pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+# Release workflow: builds sdist, creates a GitHub Release with
+# auto-generated notes, and publishes to PyPI via OIDC trusted publishing.
+# The PyPI publish step is gated on the ``pypi`` GitHub environment, which
+# is configured (in repo settings) to require manual reviewer approval.
+#
+# Tag conventions (no ``v`` prefix; SemVer-style):
+#   1.2.3            -- final release
+#   1.2.3-rc1        -- pre-releases (alpha / beta / rc; PEP 440 normalises
+#                       ``1.2.3-rc1`` to ``1.2.3rc1`` for the wheel version)
+#
+# Prerequisites (configured outside this workflow):
+#   * PyPI trusted publisher: workflow=release.yml, environment=pypi
+#   * GitHub environment ``pypi`` with required reviewers
+#   * Tag protection rule for the patterns below
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-[abr]*'
+
+permissions:
+  contents: read
+
+jobs:
+  guard_main:
+    # Refuse to release from a tag that does not point at a commit on main.
+    # Prevents accidental releases from feature branches or stale tags.
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check tag commit is an ancestor of origin/main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag commit $GITHUB_SHA is not on origin/main; refusing to release."
+            exit 1
+          fi
+
+  build:
+    name: Build artifacts
+    needs: guard_main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # hatch-vcs needs the full history (or at least tags) to resolve
+          # the version dynamically.
+          fetch-depth: 0
+
+      - name: Build wheel and sdist
+        run: pipx run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.ref_name }}
+          path: dist/*
+
+  create_github_release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+          # Mark pre-releases (anything with a/b/rc in the tag) appropriately
+          # so PyPI/users see the right channel.
+          prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
+
+  publish_pypi:
+    name: Publish to PyPI
+    needs: create_github_release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tempnet
+    permissions:
+      id-token: write       # OIDC for trusted publishing
+      attestations: write   # sigstore provenance attestations
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -1,0 +1,62 @@
+# Manual TestPyPI dry-run. Trigger via the Actions tab; the branch picker
+# in the workflow_dispatch UI selects which ref to build from. Useful for
+# validating the build and publish pipeline before cutting a real release tag.
+#
+# Prerequisites (configured outside this workflow):
+#   * TestPyPI trusted publisher: workflow=test_release.yml, environment=testpypi
+#   * GitHub environment ``testpypi`` (no reviewers required)
+
+name: Test release (TestPyPI)
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build wheel and sdist
+        # TestPyPI rejects PEP 440 local version segments (the ``+gSHA``
+        # suffix hatch-vcs appends on non-tag commits). Strip it here --
+        # and only here -- so PyPI releases and local dev installs are
+        # unaffected.
+        env:
+          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
+        run: pipx run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-testrelease
+          path: dist/*
+
+  publish_testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/tempnet
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # TestPyPI rejects re-uploads of an existing version; allow the
+          # workflow to succeed when the version already exists so repeated
+          # dry-runs from the same commit don't fail noisily.
+          skip-existing: true


### PR DESCRIPTION
This sets up an automated publishing workflow triggered on push of a new tag to `main`.

The workflow creates a GitHub Release as well as a new release on pypi.

We also add a test release workflow that allows to step through the publishing process on test.pypi.org