### PR TITLE
150 homepageintroduction documentation suggestions

### DIFF
--- a/docs/content/georacoon/index.md
+++ b/docs/content/georacoon/index.md
@@ -1,8 +1,11 @@
 # Introduction 
 
-```{toctree}
+```{include} ../../../README.md
+:start-after: <!-- overview-start -->
+:end-before: <!-- overview-end -->
+```
 
-overview
+```{toctree}
 installation
 usage
 ```

--- a/docs/content/georacoon/overview.md
+++ b/docs/content/georacoon/overview.md
@@ -1,6 +1,0 @@
-# Overview
-
-```{include} ../../../README.md
-:start-after: <!-- overview-start -->
-:end-before: <!-- overview-end -->
-```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,16 @@
 title: GeoRacoon
 ---
 
+<style>
+/* 1. Hide the Sphinx-generated Markdown title */
+h1:first-of-type { display: none !important; }
+
+/* 2. Rescue and display the HTML title that lives inside your README's center div */
+div[align="center"] h1 { display: block !important; }
+</style>
+
+# GeoRacoon
+
 
 ```{image} _static/georacoonPin.svg 
 :width: 400


### PR DESCRIPTION
We want to directly lead with a brief introduction section in the docs in order to avoid having to click through the dedicated TOC page.