### PR TITLE
Deprecate `nbrcpu` argument in favor of `n_jobs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ cvpara.apply_filter(
     img_filter=bpgaussian,
     filter_params=params_filter,
     data_as_dtype="float32",
-    nbrcpu=4,
+    n_jobs=4,
 )
 ```
 
@@ -243,7 +243,7 @@ cvpara.apply_filter(
     img_filter=bpgaussian,
     filter_params=params_filter,
     data_as_dtype="float32",
-    nbrcpu=4,
+    n_jobs=4,
 )
 ```
 </details>
@@ -270,7 +270,7 @@ weights = lfpara.compute_weights(
     block_size=(200, 200),
     include_intercept=True,
     no_data=np.nan,
-    nbrcpu=4,
+    n_jobs=4,
 )
 print(weights)
 
@@ -280,7 +280,7 @@ lfpara.compute_model(
     optimal_weights=weights,
     output_file="lst_predicted.tif",
     block_size=(200, 200),
-    nbrcpu=4,
+    n_jobs=4,
 )
 ```
 </details>

--- a/examples/exmpl_01_lst_topogradient.py
+++ b/examples/exmpl_01_lst_topogradient.py
@@ -40,7 +40,7 @@ topo_file_org = os.path.join(base_dir, "../data/example/elevation_mean_COP90_alp
 # lct_file = os.path.join(base_dir, "../data/example/lc_frac_plots_cgls2015_alps.tif")
 # count_file = os.path.join(base_dir, "../data/example/countries_alps.tif")
 
-params = dict(nbrcpu=6)
+params = dict(n_jobs=6)
 block_size = (200, 200)
 data_type = np.float32
 

--- a/examples/plot_01_lst_topogradient.py
+++ b/examples/plot_01_lst_topogradient.py
@@ -75,7 +75,7 @@ elev_band = topo_source.get_band(category=elev_cat)
 
 # %%
 # Set some general paremeters (for parallelization etc. for later use)
-params     = dict(nbrcpu=6)
+params     = dict(n_jobs=6)
 block_size = (200, 200)
 data_type  = np.float32
 

--- a/src/convster/parallel.py
+++ b/src/convster/parallel.py
@@ -680,9 +680,10 @@ def compute_entropy(source: str | Source,
     **params
         Additional optional parameters controlling multiprocessing and output:
 
-        - **nbrcpu** : int
-          Number of CPU cores to use. Defaults to the number of available
-          cores minus one.
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
+          Defaults to the number of available cores minus one.
         - **start_method** : str
           Multiprocessing start method (e.g., ``"spawn"`` or ``"fork"``).
         - **entropy_as_ubyte** : bool, optional
@@ -793,8 +794,19 @@ def compute_entropy(source: str | Source,
     manager = Manager()
     entropy_q = manager.Queue()
     start_method = params.get('start_method', None)
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
     # get number of cpu's
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
     with get_or_set_context(start_method).Pool(nbr_workers) as pool:
@@ -894,9 +906,10 @@ def compute_interaction(source: str | Source,
     **params
         Additional optional parameters controlling multiprocessing and output:
 
-        - **nbrcpu** : int
-          Number of CPU cores to use. Defaults to the number of available
-          cores minus one.
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
+          Defaults to the number of available cores minus one.
         - **start_method** : str
           Multiprocessing start method (e.g., ``"spawn"`` or ``"fork"``).
         - **interaction_as_ubyte** : bool, optional
@@ -1009,8 +1022,20 @@ def compute_interaction(source: str | Source,
     manager = Manager()
     interaction_q = manager.Queue()
     start_method = params.get('start_method', None)
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
+
     # get number of workers
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
     with get_or_set_context(start_method).Pool(nbr_workers) as pool:
@@ -1101,7 +1126,10 @@ def extract_categories(source: str | Source,
     **params
         Additional optional arguments:
 
-        - **nbrcpu** : int, number of CPU cores to use (default: available cores minus one)
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
+          Defaults to the number of available cores minus one.
         - **start_method** : str, multiprocessing start method (e.g., 'spawn' or 'fork')
         - **compress** : bool, if True, compress the final output with LZW
 
@@ -1210,8 +1238,19 @@ def extract_categories(source: str | Source,
     manager = Manager()
     blur_q = manager.Queue()
     start_method = params.get('start_method', None)
+    
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
     # get number of workers
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
     with get_or_set_context(start_method).Pool(nbr_workers) as pool:
@@ -1322,7 +1361,7 @@ def apply_filter(source: str | Source,
     **params
         Additional optional arguments:
 
-        - **nbrcpu** : int, number of CPU cores for multiprocessing.
+        - **n_jobs** : int, number of jobs to run in parallel.
         - **start_method** : str, multiprocessing start method.
         - **compress** : bool, whether to compress the final output with LZW.
 
@@ -1425,8 +1464,19 @@ def apply_filter(source: str | Source,
     # ###
     manager = Manager()
     blur_q = manager.Queue()
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
     # get number of cpu's
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', None))
     if verbose:
         print(f"using {nbr_workers=}")
 

--- a/src/coonfit/parallel.py
+++ b/src/coonfit/parallel.py
@@ -115,8 +115,9 @@ def compute_model(predictors: Collection[Band],
     **params : dict
         Optional arguments for the multiprocessing:
 
-        - nbrcpu : int, optional
-            Number of CPUs to use for parallel processing.
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
         - start_method : str, optional
             Multiprocessing start method ('fork', 'spawn', or 'forkserver').
         - compress : bool, optional
@@ -195,8 +196,19 @@ def compute_model(predictors: Collection[Band],
     manager = Manager()
     job_out_q = manager.Queue()
     start_method = params.get('start_method', None)
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
     # get number of workers
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
     with get_or_set_context(start_method).Pool(nbr_workers) as pool:
@@ -283,8 +295,9 @@ def get_XT_X(response: str | Band,
 
         Optional:
 
-        - nbrcpu : int, optional
-            Number of CPUs to use. If not set, uses (available threads - 1).
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
         - start_method : str, optional
             Starting method for multiprocessing ('fork', 'spawn', or
             'forkserver').
@@ -324,7 +337,18 @@ def get_XT_X(response: str | Band,
                         bidx=1)
     start_method = mpc_params.get('start_method', None)
     view_size = mpc_params.get('view_size')
-    nbr_workers = get_nbr_workers(number=mpc_params.get('nbrcpu', None))
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in mpc_params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = mpc_params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
+    nbr_workers = get_nbr_workers(number=mpc_params.get('n_jobs', _nworkers))
     src_profile = response.source.import_profile()
     src_width = int(src_profile.get('width'))
     src_height = int(src_profile.get('height'))
@@ -435,8 +459,9 @@ def get_optimal_betas(*predictors: Band | str,
 
         Optional:
 
-        - nbrcpu : int, optional
-            Number of CPUs to use. If not set, uses (available threads - 1).
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
         - start_method : str, optional
             Starting method for multiprocessing ('fork', 'spawn', or
             'forkserver').
@@ -483,7 +508,7 @@ def get_optimal_betas(*predictors: Band | str,
     ...     selector=selector,
     ...     include_intercept=True,
     ...     view_size=(512, 512),
-    ...     nbrcpu=4
+    ...     n_jobs=4
     ... )
     >>> weights
     {<Band: band1>: 0.523, <Band: band2>: 1.245, <Band: band3>: -0.334, 'intercept': 5.12}
@@ -507,7 +532,18 @@ def get_optimal_betas(*predictors: Band | str,
                         bidx=1)
     start_method = mpc_params.get('start_method', None)
     view_size = mpc_params.get('view_size')
-    nbr_workers = get_nbr_workers(number=mpc_params.get('nbrcpu', None))
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in mpc_params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = mpc_params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
+    nbr_workers = get_nbr_workers(number=mpc_params.get('n_jobs', _nworkers))
     src_profile = response.source.import_profile()
     src_width = int(src_profile.get('width'))
     src_height = int(src_profile.get('height'))
@@ -626,8 +662,9 @@ def get_XT_X_dependency(response: str | Band,
     **params : dict
         Optional multiprocessing arguments:
 
-        - nbrcpu : int, optional
-            Number of CPUs to use. If not set, uses (available CPUs - 1).
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
         - start_method : str, optional
             Process start method: 'spawn', 'fork', or 'forkserver'.
 
@@ -778,8 +815,9 @@ def compute_weights(response: str | Band,
         - extra_masking_band : Band or None, optional
             Additional Band object to use directly as a mask. All cells with
             value 0 are masked.
-        - nbrcpu : int, optional
-            Number of CPUs to use. If not set, uses (available CPUs - 1).
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to
+          :func:`~riogrande.helper.get_nbr_workers`.
         - start_method : str, optional
             Process start method: 'spawn', 'fork', or 'forkserver'.
 
@@ -877,7 +915,7 @@ def compute_weights(response: str | Band,
     ...     block_size=block_sizes,
     ...     limit_contribution=0.05,
     ...     sanitize_predictors=True,
-    ...     nbrcpu=4
+    ...     n_jobs=4
     ... )
 
     >>> # Detect and return linear dependencies
@@ -1083,8 +1121,18 @@ def calculate_rmse(response: str | Band,
     ssr_parts = manager.list()
     start_method = params.get('start_method', None)
 
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
     # get number of workers
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
     with get_or_set_context(start_method).Pool(nbr_workers) as pool:
@@ -1219,8 +1267,18 @@ def calculate_r2(response: str | Band,
     sst_parts = manager.list()
     start_method = params.get('start_method', None)
 
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
     # get number of workers
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
     with get_or_set_context(start_method).Pool(nbr_workers) as pool:

--- a/src/coonfit/parallel_helpers.py
+++ b/src/coonfit/parallel_helpers.py
@@ -24,6 +24,7 @@ Worker functions cover:
 
 from __future__ import annotations
 
+import warnings
 import math
 from collections.abc import Collection
 
@@ -258,8 +259,8 @@ def _check_predictor_consistency(predictors: Collection[Band],
     **params : dict
         Optional arguments for multiprocessing:
 
-        - nbrcpu : int, optional
-            Number of CPUs to use. If not set, uses (available threads - 1).
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to :func:`~riogrande.helper.get_nbr_workers`.
         - start_method : str, optional
             Starting method for multiprocessing jobs ('fork', 'spawn', or
             'forkserver').
@@ -314,7 +315,18 @@ def _check_predictor_consistency(predictors: Collection[Band],
         )
         job_params.append(jparams)
     start_method = params.get('start_method', None)
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     with get_or_set_context(start_method).Pool(nbr_workers) as pool:
         all_jobs = []
         for jparams in job_params:

--- a/src/riogrande/helper.py
+++ b/src/riogrande/helper.py
@@ -53,6 +53,7 @@ def get_nbr_workers(number: Optional[int] = None) -> int:
         Desired number of workers. If ``None``, the function will use the
         number of CPUs available via :func:`multiprocessing.cpu_count`,
         but never less than 2.
+        For values below -1, `n_cpus + 1 + n_jobs` will be used.
 
     Returns
     -------
@@ -66,11 +67,15 @@ def get_nbr_workers(number: Optional[int] = None) -> int:
 
     See Also
     --------
-    :func:`~riogrande.helper.get_or_set_context` : Return a multiprocessing context.
+    :func:`~riogrande.helper.get_or_set_context` : Return a multiprocessing
+    context.
     """
     _min_count = 2  # Hardcoded: some parallelization routines fail when < 2
+    _nbr_cpu = mpc.cpu_count()
     if number is None:
         _use = max(_min_count, mpc.cpu_count())
+    elif number < 0:
+        _use = max(2, _nbr_cpu + 1 + number)
     elif number <= _min_count:
         warnings.warn(
             message=f"For this routine to work properly at least {_min_count} "

--- a/src/riogrande/parallel.py
+++ b/src/riogrande/parallel.py
@@ -325,8 +325,8 @@ def compute_mask(source: str | Source, block_size: tuple[int, int], nodata=0, lo
     **params : dict
         Optional arguments for the multiprocessing:
 
-        - ``nbrcpu`` : int
-          Number of CPUs to use, passed to :func:`~riogrande.helper.get_nbr_workers`.
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to :func:`~riogrande.helper.get_nbr_workers`.
         - ``start_method`` : str
           Starting method for multiprocessing jobs, passed to
           :func:`~riogrande.helper.get_or_set_context`.
@@ -381,7 +381,18 @@ def compute_mask(source: str | Source, block_size: tuple[int, int], nodata=0, lo
     manager = Manager()
     aggr_q = manager.Queue()
     start_method = params.get('start_method', None)
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
 
@@ -484,8 +495,8 @@ def prepare_selector(*bands: Band, block_size: tuple[int, int], extra_masking_ba
     **params : dict
         Optional arguments for the multiprocessing:
 
-        - ``nbrcpu`` : int
-          The number of CPUs to use, passed to :func:`~riogrande.helper.get_nbr_workers`.
+        - ``n_jobs`` : int
+          Number of jobs to run in parallel, passed to :func:`~riogrande.helper.get_nbr_workers`.
         - ``start_method`` : str
           Starting method for multiprocessing jobs, passed to
           :func:`~riogrande.helper.get_or_set_context`.
@@ -534,7 +545,18 @@ def prepare_selector(*bands: Band, block_size: tuple[int, int], extra_masking_ba
     manager = Manager()
     aggr_q = manager.Queue()
     start_method = params.get('start_method', None)
-    nbr_workers = get_nbr_workers(number=params.pop('nbrcpu', None))
+
+    # TODO: remove support for nbrcpu for version 2.0.0
+    if 'nbrcpu' in params:
+        warnings.warn(
+            "The attribute `nbrcpu` is deprecated and should be replaced with "
+            "`n_jobs`."
+        )
+        _nworkers = params.pop('nbrcpu')
+    else:
+        _nworkers = None
+
+    nbr_workers = get_nbr_workers(number=params.pop('n_jobs', _nworkers))
     if verbose:
         print(f"using {nbr_workers=}")
 

--- a/tests/test_riogrande/test_helper.py
+++ b/tests/test_riogrande/test_helper.py
@@ -174,7 +174,9 @@ def test_get_nbr_workers_sequence(monkeypatch):
     - number is None: uses patched cpu_count and respects min_count.
     - number <= min_count: emits RuntimeWarning and returns min_count.
     - number > min_count: returns the provided number as int.
-    - negative min_count: cpu_count still respected when number is None.
+    - insufficient number: cpu_count is set to 2 if number in [0,1].
+    - negative number: Follow the pattern nbr_cpu + 1 + number
+    - contain negative overshooting (never below 2)
     """
     # 1) number is None -> uses cpu_count
     monkeypatch.setattr(mpc, "cpu_count", lambda: 4)
@@ -196,6 +198,16 @@ def test_get_nbr_workers_sequence(monkeypatch):
     assert get_nbr_workers(5) == 5
     assert get_nbr_workers(int(3.0)) == 3
 
+
+    # proper handling of negative numbers
+    monkeypatch.setattr(mpc, "cpu_count", lambda: 5)
+
+    assert get_nbr_workers(-1) == 5
+    assert get_nbr_workers(-2) == 4
+
+    # control for negative overshooting
+    assert get_nbr_workers(-5) == 2
+    assert get_nbr_workers(-8) == 2
 
 def run_in_subprocess(pycode):
     cmd = [sys.executable, "-c", pycode]


### PR DESCRIPTION
This is an argument renaming with a deprecation flow making sure we don't break compatibility within a major version.

Also, this implements the same evaluation logic as [joblib.Parallel's `n_jobs` argument](https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html). In particular "For n_jobs below -1, (n_cpus + 1 + n_jobs) are used.".

- [x] Rename argument
- [x] Implement "For n_jobs below -1, (n_cpus + 1 + n_jobs) are used."