### PR TITLE
Add a tests badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
   </a>
 </p>
 <p>
+  <a href="https://github.com/GeoRacoon/GeoRacoon/actions/workflows/develop.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/GeoRacoon/GeoRacoon/develop.yml?branch=main&label=Tests" alt="Tests">
+  </a>
   <a href="https://github.com/GeoRacoon/georacoon/tree/python-coverage-comment-action-data">
     <img src="https://github.com/GeoRacoon/georacoon/raw/python-coverage-comment-action-data/badge.svg" alt="Coverage">
   </a>


### PR DESCRIPTION
The badge block covers release, docs, licence, the four deploy platforms and coverage, but `develop.yml` ("Run Tests") is not referenced anywhere in the README, so the test suite is the one thing with no visible status.

Added it next to Coverage, using the same shields.io endpoint style as the surrounding badges.

Verified the badge URL returns `Tests: passing`. Left `release.yml` out since it reports no status on `main`.